### PR TITLE
Sc 3233

### DIFF
--- a/enums/routes_match.js
+++ b/enums/routes_match.js
@@ -37,47 +37,6 @@ module.exports = Object.freeze({
     },
     'GetMySellOffers': {
         route: null
-    },
+    }
 
-
-
-    'ItemHistory': {
-        route: 'my-inventory'
-    },
-    'Trades': {
-        route: 'trades'
-    },
-    'GetMoney': {
-        route: 'get-money'
-    },
-    'PingPong': {
-        route: 'ping'
-    },
-    'GoOffline': {
-        route: 'go-offline'
-    },
-    'GetToken': {
-        route: null
-    },
-    'SetToken': {
-        route: null
-    },
-    'GetWSAuth': {
-        route: 'get-ws-auth'
-    },
-    'UpdateInventory': {
-        route: 'update-inventory'
-    },
-    'itemsInCache': {
-        route: null
-    },
-    'GetDiscounts': {
-        route: null
-    },
-    'GetCounters': {
-        route: null
-    },
-    'GetMySellOffers': {
-        route:
-    },
 })

--- a/enums/routes_match.js
+++ b/enums/routes_match.js
@@ -1,0 +1,83 @@
+module.exports = Object.freeze({
+    'GetInv': {
+        route: 'my-inventory'
+    },
+    'Trades': {
+        route: 'trades'
+    },
+    'GetMoney': {
+        route: 'get-money'
+    },
+    'PingPong': {
+        route: 'ping'
+    },
+    'GoOffline': {
+        route: 'go-offline'
+    },
+    'GetToken': {
+        route: null
+    },
+    'SetToken': {
+        route: null
+    },
+    'GetWSAuth': {
+        route: 'get-ws-auth'
+    },
+    'UpdateInventory': {
+        route: 'update-inventory'
+    },
+    'itemsInCache': {
+        route: null
+    },
+    'GetDiscounts': {
+        route: null
+    },
+    'GetCounters': {
+        route: null
+    },
+    'GetMySellOffers': {
+        route: null
+    },
+
+
+
+    'ItemHistory': {
+        route: 'my-inventory'
+    },
+    'Trades': {
+        route: 'trades'
+    },
+    'GetMoney': {
+        route: 'get-money'
+    },
+    'PingPong': {
+        route: 'ping'
+    },
+    'GoOffline': {
+        route: 'go-offline'
+    },
+    'GetToken': {
+        route: null
+    },
+    'SetToken': {
+        route: null
+    },
+    'GetWSAuth': {
+        route: 'get-ws-auth'
+    },
+    'UpdateInventory': {
+        route: 'update-inventory'
+    },
+    'itemsInCache': {
+        route: null
+    },
+    'GetDiscounts': {
+        route: null
+    },
+    'GetCounters': {
+        route: null
+    },
+    'GetMySellOffers': {
+        route:
+    },
+})

--- a/src/MarketApi.js
+++ b/src/MarketApi.js
@@ -8,7 +8,7 @@ const Papa = require('papaparse');
 const queryStringify = require('querystring').stringify;
 
 const MarketApiError = require("./MarketApiError");
-
+const routesMatch = require('./../enums/routes_match');
 /**
  * API
  * https://market.csgo.com/docs/
@@ -332,9 +332,23 @@ class MarketApi {
      * @returns {Promise}
      */
     callMethodWithKey(method, gotOptions = null, params = null) {
-        let url = this.formatMethodWithKey(MarketApi.VERSIONS.V1, method, params);
+        // let url = this.formatMethodWithKey(MarketApi.VERSIONS.V1, method, params);
 
-        return this.callApiUrl(url, gotOptions);
+        /**
+         * We get the routes v1: v2 and find the match
+         */
+        let matchingRoute = routesMatch[method];
+
+        /**
+         * If method is present in v2 rewrite the method string e.g. PingPong => ping
+          * @type {string|*|String|Array}
+         */
+        method = matchingRoute.route || method;
+
+        /**
+         * If route is present in v2 call v2 method with the new string. If no, return common no success response.
+         */
+        return matchingRoute.route ? this.callV2MethodWithKey(method, gotOptions, params) : {success: false};
     }
 
     /**


### PR DESCRIPTION
A simple solution for now to switch bots to v2

`Current code:
 
 sellCreateTradeRequest(botId, type = 'out', gotOptions = null) {
        let self = this.constructor;

        let types = self.CREATE_TRADE_REQUEST_TYPE;
        let typeUpper = type.toUpperCase();
        if(!types.hasOwnProperty(typeUpper)) {
            type = types.OUT;
        } else {
            type = types[typeUpper];
        }

        let url = ['ItemRequest', type, botId];

      return this.callMethodWithKey(url, gotOptions);
  

    }
    
    callMethodWithKey(method, gotOptions = null, params = null) {
        let url = this.formatMethodWithKey(method, params);

        return this.callApiUrl(url, gotOptions);
    }
    
   ----------------------------------------------------------------------------------------------------------- 
    Let's adapt caller:
      callMethodWithKey(method, gotOptions = null, params = null) {
       
       
 +++      const endpoints_match = {
 +++         'ItemRequest': 'trade-request-take',
  +++        'someMethod': 'same-new-api-method',
  +++           ...
+++      };    

       
 +++       method[0] = endpoints_match[method[0]];
        
 +++       return this.callV2MethodWithKey(method, gotOptions, params);
        
  ---      // let url = this.formatMethodWithKey(method, params);
   ---    // return this.callApiUrl(url, gotOptions);
    }
    
    
     callV2MethodWithKey(method, gotOptions = null, params = null) {
        let url = this.formatMethodWithKey(MarketApi.VERSIONS.V2, method, params);

        return this.callApiUrl(url, gotOptions);
    }
    `